### PR TITLE
Use .bind to support .reduce/.reduceRight scope

### DIFF
--- a/src/valentine.js
+++ b/src/valentine.js
@@ -40,11 +40,11 @@
     }
 
   , reduce: function (o, i, m, c) {
-      return ap.reduce.call(o, i, m, c);
+      return ap.reduce.call(o, v.bind(c, i), m);
     }
 
   , reduceRight: function (o, i, m, c) {
-      return ap.reduceRight.call(o, i, m, c)
+      return ap.reduceRight.call(o, v.bind(c, i), m)
     }
 
   , find: function (obj, iterator, context) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -153,7 +153,22 @@ sink('Arrays', function(test, ok, before, after) {
     ok(v.lastIndexOf(['x', 'y', 'z'], 'b') == -1, 'indexOf b == -1');
   });
 
-});
+  v.each(['reduce', 'reduceRight'], function (method, right) {
+    test(method, 3, function() {
+      var init = {}, scope = {}
+      v[method]([5], function (memo, n, i, a) {
+        ok(this === scope, method + ' iterator scope')
+        ok(init === memo && a[i] === n, method + ' iterator signature')    
+      }, init, scope)
+
+      var a = ['b', 'c']
+      ok(v[method](a, function (memo, n) {
+        return memo + n
+      }, 'a') === (right ? 'acb' : 'abc'), method + ' result')
+    })
+  })
+
+})
 
 sink('Utility', function (test, ok, b, a, assert) {
   test('extend', 2, function () {


### PR DESCRIPTION
Native `[].reduce` and `[].reduceRight` lack scope support
